### PR TITLE
Fixed padding issues

### DIFF
--- a/voilab-table.js
+++ b/voilab-table.js
@@ -52,16 +52,16 @@ var lodash = require('lodash'),
         };
 
         if (border.indexOf('L') !== -1) {
-            self.pdf.moveTo(pos.x, pos.y).lineTo(pos.x, bpos.y).stroke();
+            self.pdf.save().moveTo(pos.x, pos.y).lineTo(pos.x, bpos.y).lineCap('square').stroke().restore();
         }
         if (border.indexOf('T') !== -1) {
-            self.pdf.moveTo(pos.x, pos.y).lineTo(bpos.x, pos.y).stroke();
+            self.pdf.save().moveTo(pos.x, pos.y).lineTo(bpos.x, pos.y).lineCap('square').stroke().restore();
         }
         if (border.indexOf('B') !== -1) {
-            self.pdf.moveTo(pos.x, bpos.y).lineTo(bpos.x, bpos.y).stroke();
+            self.pdf.save().moveTo(pos.x, bpos.y).lineTo(bpos.x, bpos.y).lineCap('square').stroke().restore();
         }
         if (border.indexOf('R') !== -1) {
-            self.pdf.moveTo(bpos.x, pos.y).lineTo(bpos.x, bpos.y).stroke();
+            self.pdf.save().moveTo(bpos.x, pos.y).lineTo(bpos.x, bpos.y).lineCap('square').stroke().restore();
         }
     },
 
@@ -73,29 +73,48 @@ var lodash = require('lodash'),
             },
             data = row._renderedContent.data[column.id] || '',
             renderer = isHeader ? column.headerRenderer : column.renderer,
-            y = pos.y;
+            y = pos.y,
+            x = pos.x;
 
-        if (!isHeader && column.padding) {
-            padding.left = getPaddingValue('left', column.padding);
-            padding.top = getPaddingValue('top', column.padding);
-            width -= getPaddingValue('horizontal', column.padding);
+        // Top and bottom padding (only if valign is not set)
+        if (!column.valign) {
+            if (isHeader) {
+                padding.top = getPaddingValue('top', column.headerPadding);
+                padding.bottom = getPaddingValue('bottom', column.headerPadding);
+                y += padding.top;
+            } else if (!isHeader) {
+                padding.top = getPaddingValue('top', column.padding);
+                padding.bottom = getPaddingValue('bottom', column.padding);
+                y += padding.top;
+            }
         }
-        y += padding.top;
+
+        // Left and right padding
+        if (!isHeader) {
+            padding.left = getPaddingValue('left', column.padding);
+            width -= getPaddingValue('horizontal', column.padding);
+            x += padding.left;
+        } else {
+            padding.left = getPaddingValue('left', column.headerPadding);
+            width -= getPaddingValue('horizontal', column.headerPadding);
+            x += padding.left;
+        }
+
         // if specified, cache is not used and renderer is called one more time
         if (renderer && column.cache === false) {
             data = renderer(self, row, true, column, lodash.clone(pos), padding);
         }
         // manage vertical alignement
         if (column.valign === 'center') {
-            y += (row._renderedContent.height - row._renderedContent.dataHeight[column.id]) / 2;
+            y += (row._renderedContent.height - row._renderedContent.contentHeight[column.id]) / 2;
         } else if (column.valign === 'bottom') {
-            y += (row._renderedContent.height - row._renderedContent.dataHeight[column.id]);
+            y += (row._renderedContent.height - row._renderedContent.contentHeight[column.id]);
         }
 
-        self.pdf.text(data, pos.x + padding.left, y, lodash.assign({
+        self.pdf.text(data, x, y, lodash.assign({}, column, {
             height: row._renderedContent.height,
             width: width
-        }, column));
+        }));
 
         pos.x += column.width;
     },
@@ -126,22 +145,28 @@ var lodash = require('lodash'),
         });
 
         self.pdf.y = pos.y + row._renderedContent.height;
-
-        self.pdf.moveDown(self.minRowHeight);
     },
 
     setRowHeight = function (self, row, isHeader) {
         var max_height = 0;
 
-        row._renderedContent = {data: {}, dataHeight: {}};
+        row._renderedContent = {data: {}, dataHeight: {}, contentHeight: {}};
 
         lodash.forEach(self.getColumns(), function (column) {
             var renderer = isHeader ? column.headerRenderer : column.renderer,
                 content = renderer ? renderer(self, row, false) : row[column.id],
-                height = !content ? 1 : self.pdf.heightOfString(content, lodash.assign(lodash.clone(column), {
-                    width: column.width - getPaddingValue('horizontal', column.padding)
-                })),
+                height = !content ? 1 : self.pdf.heightOfString(content, column),
                 column_height = isHeader ? column.headerHeight : column.height;
+
+            // Ssetup the content height
+            row._renderedContent.contentHeight[column.id] = height;
+
+            // Continue with the row height
+            if (isHeader) {
+                height += getPaddingValue('vertical', column.headerPadding);
+            } else {
+                height += getPaddingValue('vertical', column.padding);
+            }
 
             if (height < column_height) {
                 height = column_height;
@@ -756,6 +781,9 @@ lodash.assign(PdfTable.prototype, {
 
         // Issue #1, restore x position after table is drawn
         self.pdf.x = self.pdf.page.margins.left;
+
+        // Add margin to the bottom of the table
+        self.pdf.y += self.bottomMargin;
 
         return this;
     },


### PR DESCRIPTION
This PR improves padding on your tables and allows them to look more like tables.

- Introduces 2 new properties
  - `row._renderedContent.contentHeight` which will be the actual content size of the content inside the cell
  - `column.headerPadding` which can be used to set the padding for the header separately from the body

- Adds `bottomMargin` to the bottom of the table.
- Fixes borders so they look more like a table

## Output

Using the README example and the following defaults
```
.setColumnsDefaults({
  headerBorder: 'TRBL',
  border: 'TRBL',
  align: 'right',
  padding: [ 50, 10, 0, 10 ],
  headerPadding: [ 5, 10 ]
})
```

### Original
![image](https://cloud.githubusercontent.com/assets/793406/23270718/15a2d23e-f9f5-11e6-8f18-c1524a910325.png)

### With padding improvements
![image](https://cloud.githubusercontent.com/assets/793406/23270608/a8c09138-f9f4-11e6-9968-5efb2f2aafe0.png)
