### PR TITLE
Resets Y position when a new page is added

### DIFF
--- a/voilab-table.js
+++ b/voilab-table.js
@@ -115,6 +115,8 @@ var lodash = require('lodash'),
             self.emitter.emit('page-add', self, row, ev);
             if (!ev.cancel) {
                 self.pdf.addPage();
+                // Reset Y position for next page
+                pos.y = self.pdf.page.margins.top;
             }
             self.emitter.emit('page-added', self, row);
         }


### PR DESCRIPTION
The current implementation doesn't reset `pos.y` when a new page is added in the `addRow` function so the table continues in the same Y position on the next page. This adds a statement to reset the y to the top margin as long as the event is not being cancelled.