### PR TITLE
Feature/cell width

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,25 @@ table.onPageAdd(function (table, row, ev) {
 
 ## Changelogs
 
+### Col span
+
+You can customize the single cells width by defining the "columnSpan" property and defining an object instead of a plain text content.
+
+```js
+    const tableBody = [
+        {
+            columnA: "firstRowFirstCell",
+            columnB: "firstRowSecondCell"
+        },
+        {
+            columnA: {
+                content:"secondRowUniqueCell", 
+                colSpan: 2
+            }
+        }
+    ]
+```
+
 ### 0.4.0
 Thank you, contributors!
 


### PR DESCRIPTION
Hi,
I tried to add the "colSpan" feature, in order to allow users to define an attribute which is similar to common html.
You can use this feature by defining your cells as object with a "content" and a "colSpan" attributes, instead of plain text (but you can still use the plain text version of the cell).

Take a look at the README to see how to use this feature.

Thank u