### PR TITLE
simplify setRowHeight

### DIFF
--- a/voilab-table.js
+++ b/voilab-table.js
@@ -184,9 +184,11 @@ var lodash = require('lodash'),
         lodash.forEach(self.getColumns(), function (column) {
             var renderer = isHeader ? column.headerRenderer : column.renderer,
                 content = renderer ? renderer(self, row, false, column) : row[column.id],
-                height = !content || column.ellipsis ? 1 : self.pdf.heightOfString(content, lodash.assign(lodash.clone(column), {
-                    width: column.width - getPaddingValue('horizontal', column.padding)
-                })),
+                height = !content || column.ellipsis ? 1 : self.pdf.heightOfString(content, {
+                  width: column.padding
+                    ? column.width - getPaddingValue('horizontal', column.padding)
+                    : column.width
+                }),
                 column_height = isHeader ? column.headerHeight : column.height;
 
             // Setup the content height


### PR DESCRIPTION
Removes a call to lodash.assign and a call to lodash.clone, which reduces the amount of CPU and memory used. It isn't a massive improvement, but something I noticed in the profiler while looking into optimizing other things in PDFKit.

On a simple 500 row PDF -

Before:
<img width="956" alt="Screen Shot 2019-11-26 at 12 44 52 PM" src="https://user-images.githubusercontent.com/425716/69662926-e0997880-104a-11ea-8fce-5cf131c2b405.png">

After:
<img width="726" alt="Screen Shot 2019-11-26 at 12 42 24 PM" src="https://user-images.githubusercontent.com/425716/69662933-e42cff80-104a-11ea-8276-3fd488f01233.png">
