### PR TITLE
fix: respect provided y position for addRow

### DIFF
--- a/voilab-table.js
+++ b/voilab-table.js
@@ -144,7 +144,7 @@ var lodash = require('lodash'),
     addRow = function (self, row, index, isHeader) {
         var pos = {
                 x: self.pos.x || self.pdf.page.margins.left,
-                y: self.pdf.y
+                y: index === 0 ? self.pos.y : self.pdf.y
             },
             ev = {
                 cancel: false


### PR DESCRIPTION
I figured that the current state of this addon does not allow arbitrarily setting the initial y position and will be the value of the current pdf position. Sometimes it comes handy to be able to set it, since I can set the x position [too](https://github.com/voilab/voilab-pdf-table/blob/0.5.1/voilab-table.js#L262) (unsure if thats supposed to do or not).

With this change it allows to define the y start position like so:

```
const doc = new PDFDocument({
    layout: 'landscape',
});

const imageWidth = 200;
const additionalLeftPadding = 30;

doc.image(
    `${__dirname}/sample.jpg`,
    doc.page.margins.left,
    doc.page.margins.top,
    { width: imageWidth }
);

const table = new PDFTable(doc, {
    pos: {
        y: doc.page.margins.top,  // <---- Thats the part which is working as expected now
        x: doc.page.margins.left + imageWidth + additionalLeftPadding
    }
});

table.addColumns([
    {
        id: 'product',
        header: 'Product',
        width: 70,
        padding: [5, 0],
        border: 'T',
    },
    {
        id: 'quantity',
        header: 'Quantity',
        width: 70,
        padding: [5, 0],
        border: 'T',
    },
    {
        id: 'price',
        header: 'Price',
        width: 70,
        padding: [5, 0],
        border: 'T',
    },
    {
        id: 'total',
        header: 'Total',
        width: 70,
        padding: [5, 0],
        border: 'T',
    },
]);

table.addBody([
    {product: 'Product 1', quantity: 1, price: 20.10, total: 20.10},
    {product: 'Product 2', quantity: 4, price: 4.00, total: 16.00},
    {product: 'Product 3', quantity: 2, price: 17.85, total: 35.70}
]);
```

Without this change:
![Selection_005](https://user-images.githubusercontent.com/6084030/175090847-d637be5b-375d-44a3-9061-d2c50502ba75.png)

With this change:
![Selection_006](https://user-images.githubusercontent.com/6084030/175090977-90d59510-ea47-4b5a-a830-10cfa389ce88.png)


I could made it working with setting the y posititon of the pdf itself before creating the table (`doc.y = doc.page.margins.top;`), since I'm not familiar with best practises I don't know if that would be the way to go. My first intention was by passing it to the constructor, which surprisingly didn't work.
